### PR TITLE
Support Krastorio 2 Spaced Out v2.0

### DIFF
--- a/compat/krastorio2-so.lua
+++ b/compat/krastorio2-so.lua
@@ -132,7 +132,12 @@ if settings.startup["disable-hyper-belts"].value == false then
 
     if settings.startup["kr-loaders"].value then
 
-    local graphics = require("__Krastorio2-spaced-out__.prototypes.buildings.loader-graphics")
+    local graphics = nil
+    if (mods["Krastorio2"]) then
+        graphics = require("__Krastorio2__.prototypes.buildings.loader-graphics")
+    else
+        graphics = require("__Krastorio2-spaced-out__.prototypes.buildings.loader-graphics")
+    end
     local sounds = require("__base__.prototypes.entity.sounds")
 
     data:extend({


### PR DESCRIPTION
Krastorio 2 Spaced Out v2.0 requires Krastorio 2, and graphics for it have changed.

This patch checks to see if Krastorio 2 is active, and prefers the graphic for loaders from there instead. Since K2SO <2.0 is incompatible with K2, it works with both versions.